### PR TITLE
GitHub Webhook 수신 시스템 기초 구축 완료

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -7,7 +7,7 @@ var bodyParser = require('body-parser');
 
 var index = require('./routes/index');
 var api = require('./routes/api');
-var webhook = require('./route/webhook');
+var webhook = require('./routes/webhook');
 
 var app = express();
 

--- a/server/app.js
+++ b/server/app.js
@@ -7,6 +7,7 @@ var bodyParser = require('body-parser');
 
 var index = require('./routes/index');
 var api = require('./routes/api');
+var webhook = require('./route/webhook');
 
 var app = express();
 
@@ -22,6 +23,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', index);
 app.use('/api', api);
+app.use('/webhook', webhook);
 
 app.use(function(req, res, next) {
   var err = new Error('Not Found');

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -12,4 +12,36 @@ router.get('/', function(req, res, next) {
   });
 });
 
+/**
+ * 멤버를 추가합니다.
+ */
+router.post('/member/add', function(req, res, next) {
+  // 먼저 중복 검사를 수행합니다.
+  models.Members.findOne({ where: {email: req.body.email} }).then(result => {
+    if (result) {
+      res.json({
+        result: 1,
+        error_desc: "이미 존재하는 E-mail 주소입니다."
+      });
+    } else {
+      // 중복 검사를 통과했다면, 새로운 Member를 추가합니다.
+      models.Members.findOrCreate({
+        where: {
+          name: req.body.name,
+          phone: req.body.phone,
+          email: req.body.email,
+          github: req.body.github,
+          group: req.body.group
+        }, 
+      }).spread((user, created) => {
+        console.log("[+] /member/add : 새로운 멤버가 추가되었습니다 : \n", user.get({plain: true}));
+        res.json({
+          result: 0,
+          member: user.get({plain: true})
+        });
+      });
+    }
+  });
+});
+
 module.exports = router;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -15,12 +15,9 @@ router.get('/', function(req, res, next) {
   });
 });
 
-<<<<<<< HEAD
 /**
  * 멤버를 추가합니다.
  */
-=======
->>>>>>> db071c3566d55df63fcd5f246607e1150af4afd6
 router.post('/member/add', function(req, res, next) {
   // 먼저 중복 검사를 수행합니다.
   models.Members.findOne({ where: {email: req.body.email} }).then(result => {

--- a/server/routes/webhook.js
+++ b/server/routes/webhook.js
@@ -1,0 +1,49 @@
+var express = require('express');
+var router = express.Router();
+
+var hackathoners = require('../hackathoners');
+var models = hackathoners.db.model;
+
+/**
+ * 각 팀들의 Github Project에서 나오는 PushEvent Webhook을 처리합니다.
+ * Webhook의 형식은 다음 링크를 참조하십시오 :
+ * https://developer.github.com/v3/activity/events/types/#pushevent
+ * Header의 경우 위조 방지를 위해 [!] 표시 항목에 대하여 무결성 검사를 선행합니다 :
+ *   POST /payload HTTP/1.1
+ *   ...
+ *   [!] X-Github-Delivery: [UUID]
+ *   [!] User-Agent: GitHub-Hookshot/[고유 문자]
+ *   [!] X-GitHub-Event: push
+ */
+router.post('/', function(req, res, next) {
+  var payload = req.body;
+  /**
+   * socket.io를 통해 클라이언트로 전달되는 Parameter입니다.
+   * 아래에서 사람을 뜻하는 owner, pusher, committer 따위의 요소들은
+   * "name", "email"을 포함하는 JSON Object입니다.
+   */
+  var result = {
+    // Repository 관련 내용입니다.
+    repo: {
+      // Repository의 이름입니다.
+      name: payload.repository.name,
+      // Repository의 소유자입니다. JSON Object로 되어있습니다.
+      owner: payload.repository.owner
+    },
+    // Push를 발생시킨 사람입니다. JSON Object로 되어있습니다.
+    pusher: payload.pusher,
+    // Head Commit에 대한 내용입니다.
+    commit: {
+      // Commit Message입니다.
+      message: payload.head_commit.message,
+      // Commit Timestamp입니다.
+      timestamp: payload.head_commit.timestamp,
+      // Commit을 한 사람입니다. JSON Object로 되어있습니다.
+      // committer는 상기한 속성 외에 "username"이 추가로 붙어있습니다.
+      committer: payload.head_commit.committer
+    }
+  }
+  console.log(result);
+});
+
+module.exports = router;

--- a/server/routes/webhook.js
+++ b/server/routes/webhook.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var request = require('request');
 var router = express.Router();
 
 var hackathoners = require('../hackathoners');
@@ -8,6 +9,7 @@ var models = hackathoners.db.model;
  * 각 팀들의 Github Project에서 나오는 PushEvent Webhook을 처리합니다.
  * Webhook의 형식은 다음 링크를 참조하십시오 :
  * https://developer.github.com/v3/activity/events/types/#pushevent
+ * 
  * Header의 경우 위조 방지를 위해 [!] 표시 항목에 대하여 무결성 검사를 선행합니다 :
  *   POST /payload HTTP/1.1
  *   ...
@@ -17,6 +19,7 @@ var models = hackathoners.db.model;
  */
 router.post('/', function(req, res, next) {
   var payload = req.body;
+
   /**
    * socket.io를 통해 클라이언트로 전달되는 Parameter입니다.
    * 아래에서 사람을 뜻하는 owner, pusher, committer 따위의 요소들은
@@ -40,10 +43,28 @@ router.post('/', function(req, res, next) {
       timestamp: payload.head_commit.timestamp,
       // Commit을 한 사람입니다. JSON Object로 되어있습니다.
       // committer는 상기한 속성 외에 "username"이 추가로 붙어있습니다.
-      committer: payload.head_commit.committer
+      committer: payload.head_commit.committer,
+      // 해당 Repository의 전체 Commit Count입니다. 하단의 request를 통해서 반영됩니다.
+      full_count: undefined
     }
   }
-  console.log(result);
+
+  var options = {
+    url: "https://api.github.com/repos/" + payload.repository.full_name,
+    headers: {
+      'User-Agent': 'request'
+    }
+  };
+
+  request(options, function(error, response, body) {
+    result.commit.full_count = JSON.parse(response.body).size;
+    /**
+     * 현재는 테스트 구현으로, 실제 구현에서는 이 부분에 socket.io를 통한
+     * Event Emit이 이루어질 예정입니다.
+     */
+    console.log(result);
+    res.json(result);
+  });
 });
 
 module.exports = router;


### PR DESCRIPTION
이제 `/webhook`에서 Github Webhook을 통합하여 수신하고 처리할 수 있는
인터페이스가 구축되었습니다. 기본적으로는, `PushEvent`를 수신한 후에
이를 적합한 형태로 가공한 후 Repository의 Commit Count를 받아오기 위한
추가 Request를 날려서 최종적으로 데이터를 확정한 후 이를 `socket.io`
Event Emit으로 내보내는 방식입니다. 현재는 `socket.io` 관련 구현이
없어서 `res.json()`과 `console.log()`를 이용하여 디버깅에 이용할 수
있도록 해두었습니다.

현재는 `request` 함수의 오류 처리가 되어있지 않고, Webhook을 흉내낸 POST
데이터로부터 적합한 가공 데이터를 뽑아내는 과정만을 규명한 상태입니다.
다음 Commit에서부터 MySQL Database와의 통신을 통한 데이터 정리와 오류
처리 등의 구현을 추가할 예정입니다.

이 Commit과 관련된 이슈는 #11 입니다.

Signed-off-by: harrydrippin <hj332921@gmail.com>